### PR TITLE
pin generic-rake.yml to @v1.1.0 immutable tag

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/generic-rake.yml@v1
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@v1.1.0
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Refs https://github.com/metanorma/cimas/issues/68

## Summary

Pins `generic-rake.yml` from moving `@v1` to immutable `@v1.1.0`, per the three-tier tagging discipline established in [`metanorma/ci#372`](https://github.com/metanorma/ci/pull/372) (merged 2026-07-28). Validates the immutable-tag semantics in production before Phase 2 bulk conversion scales.

## Context

This consumer was converted from a cimas-managed local workflow file to a `uses:` reference in [`metanorma-cc#509`](https://github.com/metanorma/metanorma-cc/pull/509) (canary #1). That PR pinned to moving `@v1` because immutable tags did not yet exist on `metanorma/ci`. Post-`ci#372`, `v1.1.0` is now the first immutable release + `v1.1` and `v1` are moving pointers (three-tier convention per actions/checkout).

## Test plan

- [ ] CI green (existing matrix should carry through — `@v1` and `@v1.1.0` currently point at the same commit).

🤖
