### PR TITLE
pin rubygems-release.yml to @v1.1.0 immutable tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: metanorma/ci/.github/workflows/rubygems-release.yml@v1
+    uses: metanorma/ci/.github/workflows/rubygems-release.yml@v1.1.0
     with:
       next_version: ${{ github.event.inputs.next_version }}
       # Explicit release_command needed since metanorma/ci#314 deprecated


### PR DESCRIPTION
Refs https://github.com/metanorma/cimas/issues/68

## Summary

Pins `rubygems-release.yml` from moving `@v1` to immutable `@v1.1.0`, per the three-tier tagging discipline established in [`metanorma/ci#372`](https://github.com/metanorma/ci/pull/372) (merged 2026-07-28). Validates the immutable-tag semantics in production before Phase 2 bulk conversion scales.

## Context

This consumer was converted from a cimas-managed local workflow file to a `uses:` reference in [`metanorma-cc#510`](https://github.com/metanorma/metanorma-cc/pull/510) (canary #2). That PR pinned to moving `@v1` because immutable tags did not yet exist on `metanorma/ci`. Post-`ci#372`, `v1.1.0` is now the first immutable release + `v1.1` and `v1` are moving pointers (three-tier convention per actions/checkout).

## Test plan

- [ ] CI green (existing matrix should carry through — `@v1` and `@v1.1.0` currently point at the same commit).

🤖
